### PR TITLE
Make mockneat code more idiomatic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
         <apache.shale.version>1.0.5</apache.shale.version>
-        <mockneat.version>0.3.0</mockneat.version>
+        <mockneat.version>0.3.1</mockneat.version>
 
         <jsonpath.version>2.2.0</jsonpath.version>
         <jackson.version>2.9.8</jackson.version>

--- a/src/test/java/com/wildbeeslabs/sensiblemetrics/comparalyzer/AbstractDeliveryInfoDiffComparatorTest.java
+++ b/src/test/java/com/wildbeeslabs/sensiblemetrics/comparalyzer/AbstractDeliveryInfoDiffComparatorTest.java
@@ -27,6 +27,7 @@ import com.wildbeeslabs.sensiblemetrics.comparalyzer.entity.DeliveryInfo;
 import lombok.extern.slf4j.Slf4j;
 import net.andreinc.mockneat.MockNeat;
 import net.andreinc.mockneat.abstraction.*;
+import net.andreinc.mockneat.types.enums.MarkovChainType;
 import net.andreinc.mockneat.types.enums.StringType;
 import net.andreinc.mockneat.unit.objects.Reflect;
 
@@ -34,6 +35,19 @@ import java.time.LocalDate;
 import java.util.Comparator;
 
 import static com.wildbeeslabs.sensiblemetrics.comparalyzer.utils.DateUtils.toDate;
+import static net.andreinc.mockneat.types.enums.MarkovChainType.LOREM_IPSUM;
+import static net.andreinc.mockneat.types.enums.StringType.ALPHA_NUMERIC;
+import static net.andreinc.mockneat.types.enums.StringType.LETTERS;
+import static net.andreinc.mockneat.types.enums.StringType.NUMBERS;
+import static net.andreinc.mockneat.unit.objects.Filler.filler;
+import static net.andreinc.mockneat.unit.seq.LongSeq.longSeq;
+import static net.andreinc.mockneat.unit.text.Markovs.markovs;
+import static net.andreinc.mockneat.unit.text.Strings.strings;
+import static net.andreinc.mockneat.unit.time.LocalDates.localDates;
+import static net.andreinc.mockneat.unit.types.Doubles.doubles;
+import static net.andreinc.mockneat.unit.types.Floats.floats;
+import static net.andreinc.mockneat.unit.types.Ints.ints;
+import static net.andreinc.mockneat.unit.types.Longs.longs;
 
 /**
  * Abstract delivery info unit test
@@ -48,30 +62,30 @@ public abstract class AbstractDeliveryInfoDiffComparatorTest {
     /**
      * Default mockNeat unit numeric instances
      */
-    protected final MockUnitInt mockUnitThousand = getMockNeat().ints().range(1, 999);
-    protected final MockUnitInt mockUnitMonth = getMockNeat().ints().range(1, 12);
-    protected final MockUnitInt mockUnitCode = getMockNeat().ints().bound(10);
-    protected final MockUnitInt mockUnitInt = getMockNeat().ints().bound(1000000);
-    protected final MockUnitLong mockUnitLong = getMockNeat().longs().bound(10000000);
-    protected final MockUnitInt mockUnitByte = getMockNeat().ints().bound(255);
-    protected final MockUnitInt mockUnitShort = getMockNeat().ints().bound(15000);
-    protected final MockUnitInt rangeMockUnitInt = getMockNeat().ints().range(1000, 5000);
-    protected final MockUnitLong rangeMockUnitLong = getMockNeat().longs().range(100000, 500000);
-    protected final MockUnitDouble mockUnitDouble = getMockNeat().doubles().bound(50000);
-    protected final MockUnitFloat mockUnitFloat = getMockNeat().floats().bound(5000);
+    protected final MockUnitInt mockUnitThousand = ints().range(1, 999);
+    protected final MockUnitInt mockUnitMonth = ints().range(1, 12);
+    protected final MockUnitInt mockUnitCode = ints().bound(10);
+    protected final MockUnitInt mockUnitInt = ints().bound(1000000);
+    protected final MockUnitLong mockUnitLong = longs().bound(10000000);
+    protected final MockUnitInt mockUnitByte = ints().bound(255);
+    protected final MockUnitInt mockUnitShort = ints().bound(15000);
+    protected final MockUnitInt rangeMockUnitInt = ints().range(1000, 5000);
+    protected final MockUnitLong rangeMockUnitLong = longs().range(100000, 500000);
+    protected final MockUnitDouble mockUnitDouble = doubles().bound(50000);
+    protected final MockUnitFloat mockUnitFloat = floats().bound(5000);
     /**
      * Default mockNeat unit localdate instances
      */
-    protected final MockUnitLocalDate mockUnitLocalDate = getMockNeat().localDates();
-    protected final MockUnitLocalDate yearMockUnitLocalDate = getMockNeat().localDates().thisYear();
-    protected final MockUnitLocalDate pastMockUnitLocalDate = getMockNeat().localDates().past(LocalDate.now().minusYears(3));
-    protected final MockUnitLocalDate futureMockUnitLocalDate = getMockNeat().localDates().future(LocalDate.now().plusYears(3));
+    protected final MockUnitLocalDate mockUnitLocalDate = localDates();
+    protected final MockUnitLocalDate yearMockUnitLocalDate = localDates().thisYear();
+    protected final MockUnitLocalDate pastMockUnitLocalDate = localDates().past(LocalDate.now().minusYears(3));
+    protected final MockUnitLocalDate futureMockUnitLocalDate = localDates().future(LocalDate.now().plusYears(3));
     /**
      * Default mockNeat unit string instances
      */
-    protected final MockUnitString alphaNumbericMockUnitString = getMockNeat().strings().types(StringType.ALPHA_NUMERIC);
-    protected final MockUnitString lettersMockUnitString = getMockNeat().strings().types(StringType.LETTERS);
-    protected final MockUnitString numbersMockUnitString = getMockNeat().strings().types(StringType.NUMBERS);
+    protected final MockUnitString alphaNumbericMockUnitString = strings().types(ALPHA_NUMERIC);
+    protected final MockUnitString lettersMockUnitString = strings().types(LETTERS);
+    protected final MockUnitString numbersMockUnitString = strings().types(NUMBERS);
 
     /**
      * Default delivery info comparator
@@ -83,26 +97,14 @@ public abstract class AbstractDeliveryInfoDiffComparatorTest {
             .thenComparing(DeliveryInfo::getCreatedAt)
             .thenComparing(DeliveryInfo::getUpdatedAt);
 
-    protected Reflect<DeliveryInfo> getDeliveryInfoReflect() {
-        return mockNeat.reflect(DeliveryInfo.class)
-                .field("id", mockUnitLong.val())
-                .field("type", mockUnitInt.val())
-                .field("description", lettersMockUnitString.val())
-                .field("createdAt", toDate(mockUnitLocalDate.val()))
-                .field("updatedAt", toDate(mockUnitLocalDate.val()));
-    }
 
-    protected DeliveryInfo getDeliveryInfo() {
-        final DeliveryInfo deliveryInfoComparable = new DeliveryInfo();
-        deliveryInfoComparable.setId(mockNeat.longSeq().start(100).increment(100).val());
-        deliveryInfoComparable.setType(mockUnitInt.val());
-        deliveryInfoComparable.setDescription(lettersMockUnitString.val());
-        deliveryInfoComparable.setCreatedAt(toDate(mockUnitLocalDate.val()));
-        deliveryInfoComparable.setUpdatedAt(toDate(mockUnitLocalDate.val()));
-        return deliveryInfoComparable;
-    }
-
-    protected MockNeat getMockNeat() {
-        return this.mockNeat;
+    protected MockUnit<DeliveryInfo> getDeliveryInfoUnit() {
+        return filler(() -> new DeliveryInfo())
+                .setter(DeliveryInfo::setId, mockUnitLong)
+                .setter(DeliveryInfo::setType, mockUnitInt)
+                .setter(DeliveryInfo::setDescription, lettersMockUnitString)
+                .setter(DeliveryInfo::setCreatedAt, mockUnitLocalDate.toUtilDate())
+                .setter(DeliveryInfo::setUpdatedAt, mockUnitLocalDate.toUtilDate());
     }
 }
+

--- a/src/test/java/com/wildbeeslabs/sensiblemetrics/comparalyzer/comparator/impl/DeliveryInfoDiffComparatorTest.java
+++ b/src/test/java/com/wildbeeslabs/sensiblemetrics/comparalyzer/comparator/impl/DeliveryInfoDiffComparatorTest.java
@@ -56,8 +56,8 @@ public class DeliveryInfoDiffComparatorTest extends AbstractDeliveryInfoDiffComp
 
     @Before
     public void setUp() {
-        this.deliveryInfoFirst = getDeliveryInfoReflect().val();
-        this.deliveryInfoLast = getDeliveryInfoReflect().val();
+        this.deliveryInfoFirst = getDeliveryInfoUnit().val();
+        this.deliveryInfoLast = getDeliveryInfoUnit().val();
     }
 
     @Test


### PR DESCRIPTION
- Increased mockneat version to 0.3.1 
- Make mockneat code more idiomatic - in the latest version it's recommended to use the shortcut methods instead of referencing MockNeat.threadLocal(), also reflect() should be replaced by filler() whenever it's possible.